### PR TITLE
Add theme toggle

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,8 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Retro-inspired music studio" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#081820" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#E0F8D0" />
+    <link rel="icon" type="image/png" href="/generated-icon.png" />
+    <title>GBA Studio</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/components/AppNavigation.tsx
+++ b/client/src/components/AppNavigation.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
-import { useLocation, useRoute, Link } from 'wouter';
+import React from 'react';
+import { useLocation, Link } from 'wouter';
 import { Button } from './ui/button';
+import { Sun, Moon } from 'lucide-react';
+import { useDarkMode } from '@/hooks/useDarkMode';
 
 interface NavigationItem {
   id: string;
@@ -11,6 +13,7 @@ interface NavigationItem {
 
 export default function AppNavigation() {
   const [location] = useLocation();
+  const { isDark, toggle } = useDarkMode();
   
   const navigationItems: NavigationItem[] = [
     {
@@ -79,8 +82,17 @@ export default function AppNavigation() {
           ))}
         </div>
         
-        {/* Right side items / user info */}
-        <div className="user-info">
+        {/* Right side items */}
+        <div className="flex items-center gap-2">
+          <Button
+            size="icon"
+            variant="outline"
+            aria-label="Toggle theme"
+            onClick={toggle}
+            className="gba-pixel-border w-8 h-8 bg-[--gba-dark] text-[--gba-lightest] hover:bg-[--gba-darker]"
+          >
+            {isDark ? <Sun className="size-4" /> : <Moon className="size-4" />}
+          </Button>
           <Link href="/coins">
             <Button
               size="sm"

--- a/client/src/hooks/useDarkMode.ts
+++ b/client/src/hooks/useDarkMode.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+export function useDarkMode() {
+  const [isDark, setIsDark] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark' || stored === 'light') return stored === 'dark';
+      return window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (isDark) {
+      root.classList.remove('light');
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+      root.classList.add('light');
+    }
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  }, [isDark]);
+
+  const toggle = () => setIsDark(v => !v);
+  return { isDark, toggle };
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -72,6 +72,20 @@ body {
     --gba-lightest: #E0F8D0;
   }
 
+  .dark {
+    --gba-darkest: #081820;
+    --gba-dark: #346856;
+    --gba-light: #88C070;
+    --gba-lightest: #E0F8D0;
+  }
+
+  .light {
+    --gba-darkest: #E0F8D0;
+    --gba-dark: #88C070;
+    --gba-light: #346856;
+    --gba-lightest: #081820;
+  }
+
   * {
     @apply border-border;
   }


### PR DESCRIPTION
## Summary
- allow switching between light and dark themes
- persist theme preference in localStorage with new `useDarkMode` hook
- update navigation bar with a sun/moon toggle button
- support theme CSS variables for `.dark` and `.light` modes
- add metadata and default class to `index.html`

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865f1381c3883329928f7ae68f84fb8